### PR TITLE
Update URL and version of flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
     -   id: debug-statements
     -   id: trailing-whitespace
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
     hooks:
     -   id: flake8
         additional_dependencies: [pep8-naming]


### PR DESCRIPTION
Flake8 has moved to GitHub and their GitLab repository is not accessible anymore, so the `pre-commit` configuration for flake8 tests need to be updated.

Unfortunately tests seem to break for other reasons under Python 3.8 and 3.10, and I have no time to investigate these failures.