### PR TITLE
update readme, add yaml to configure old hostnames

### DIFF
--- a/.helm/adhoc/old-hostname.yaml
+++ b/.helm/adhoc/old-hostname.yaml
@@ -4,7 +4,7 @@ metadata:
   name: spatial-old-hostname-certificate
 spec:
   secretName: spatial-old-hostname-secret
-  renewBefore: 120h 
+  renewBefore: 120h
   commonName: hbp-spatial-backend.apps.hbp.eu
   isCA: false
   privateKey:
@@ -36,7 +36,7 @@ spec:
         backend:
           service:
             name: prod-hbp-spatial-backend
-            port: 
+            port:
               number: 8080
   tls:
   - secretName: spatial-old-hostname-secret

--- a/.helm/adhoc/old-hostname.yaml
+++ b/.helm/adhoc/old-hostname.yaml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: spatial-old-hostname-certificate
+spec:
+  secretName: spatial-old-hostname-secret
+  renewBefore: 120h 
+  commonName: hbp-spatial-backend.apps.hbp.eu
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+  - server auth
+  dnsNames:
+  # (CHANGE ME! same as `commonName`)
+  - hbp-spatial-backend.apps.hbp.eu
+  issuerRef:
+    name: letsencrypt-production-issuer-1
+    kind: ClusterIssuer
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spatial-old-hostname-ingress
+  labels:
+    name: spatial-old-hostname-ingress
+spec:
+  rules:
+  - host: hbp-spatial-backend.apps.hbp.eu
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: prod-hbp-spatial-backend
+            port: 
+              number: 8080
+  tls:
+  - secretName: spatial-old-hostname-secret
+    hosts:
+    - hbp-spatial-backend.apps.hbp.eu

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Public deployments
 
 A production deployment (following the ``master`` branch) is deployed on https://hbp-spatial-backend.apps.hbp.eu. |uptime-prod|
 
-The ``dev`` branch is deployed on https://hbp-spatial-backend.apps-dev.hbp.eu. |uptime-dev|
+A docker image is pushed to `docker-registry.ebrains.eu/hbp-spatial-backend/server:latest <https://docker-registry.ebrains.eu/harbor/projects/112/repositories/server>`_
 
-The public deployments are managed by OpenShift clusters, the relevant configuration is described in `<openshift-deployment/>`_.
+The public deployments are managed by helm and kubernetes, the relevant configuration is described in `<.helm/>`_.
 
 
 Documentation
@@ -240,6 +240,4 @@ This repository uses `pre-commit`_ to ensure that all committed code follows min
 
 .. |uptime-prod| image:: https://img.shields.io/uptimerobot/ratio/7/m783468831-04ba4c898048519b8c7b5a2f?style=flat-square
    :alt: Weekly uptime ratio of the production instance
-.. |uptime-dev| image:: https://img.shields.io/uptimerobot/ratio/7/m783468851-2872ab9d303cfa0973445798?style=flat-square
-   :alt: Weekly uptime ratio of the development instance
 .. _pre-commit: https://pre-commit.com/


### PR DESCRIPTION
This PR updates the readme on deployment details. This PR also adds the yaml that configures the ssl certificate and ingress of old hostname (hbp-spatial-backend.apps.hbp.eu)